### PR TITLE
Fix #33 Ex Nihilo ores having triple output in high oven

### DIFF
--- a/src/main/java/kr/loveholy/exastrisrebirth/compatibility/ModTSteelworks.java
+++ b/src/main/java/kr/loveholy/exastrisrebirth/compatibility/ModTSteelworks.java
@@ -12,7 +12,7 @@ import toops.tsteelworks.api.highoven.ISmeltingRegistry;
 
 public class ModTSteelworks {
 	public static final int ingotLiquidValue = TConstruct.ingotLiquidValue;
-	public static final int ingotCostHighoven = TConstruct.ingotLiquidValue * 3;
+	public static final int ingotCostHighoven = TConstruct.ingotLiquidValue;
 	private static ISmeltingRegistry instance;
 	public static void init()
 	{


### PR DESCRIPTION
Fixes #33 where the ex nihilo ores would have triple the output of any other ore in the high oven (meaning if the config was set to 3 ingots per ore, then ex nihilo ores would output 9 ingots per ore).