### PR TITLE
Fix bound hammer having a mining speed of 1

### DIFF
--- a/src/main/java/kr/loveholy/exastrisrebirth/item/ItemHammerBound.java
+++ b/src/main/java/kr/loveholy/exastrisrebirth/item/ItemHammerBound.java
@@ -234,7 +234,8 @@ public class ItemHammerBound extends ItemHammerBase implements IBindable{
             return 0.0F;
         }
 
-        return super.func_150893_a(par1ItemStack, par2Block);
+        // return super.func_150893_a(par1ItemStack, par2Block); // Seems to always return one (or zero?)
+        return efficiencyOnProperMaterial;
     }
 
     @Override


### PR DESCRIPTION
The bound hammer is super slow on everything. It seems to be using the default item mining speed, which is probably either 1 or 0. Changed to use the already existing mining speed. This might need to be reworked to account for efficiency enchants?